### PR TITLE
feat: agent-safety git rules (push-to-main, remote delete, merge-on-main)

### DIFF
--- a/lib/command-safety/rules/git.sh
+++ b/lib/command-safety/rules/git.sh
@@ -104,6 +104,167 @@ _fix GIT_CHERRY_PICK_ABORT \
     "git cherry-pick --continue  # Resolve conflicts and continue" \
     "git cherry-pick --skip      # Skip this commit only"
 
+# =============================================================================
+# Agent Safety Rules — Protect Main Branch & Remote State
+# =============================================================================
+# These rules prevent AI agents (or hasty humans) from bypassing PR workflow.
+# Protected branches: COMMAND_SAFETY_PROTECTED_BRANCHES (default: "main master")
+# Bypass all: add the per-rule --force-* flag to the command.
+# Bypass all agent-safety rules: export COMMAND_SAFETY_DISABLE_AGENT_SAFETY=true
+#   (same as setting COMMAND_SAFETY_DISABLE_GIT=true but scoped)
+# =============================================================================
+
+# --- Helper: check if a branch name is in the protected list ---
+# Usage: _cs_is_protected_branch "main"
+# Reads: COMMAND_SAFETY_PROTECTED_BRANCHES (space-separated, default "main master")
+_cs_is_protected_branch() {
+    local name="$1"
+    local b
+    for b in ${COMMAND_SAFETY_PROTECTED_BRANCHES:-main master}; do
+        [[ "$name" == "$b" ]] && return 0
+    done
+    return 1
+}
+
+# --- match_fn: detect push to a protected branch in all refspec forms ---
+# Handles: git push origin main / git push origin HEAD:main /
+#          git push origin feature:main / git push origin +main /
+#          git push (bare on main) / git push origin (on main)
+_cs_match_push_to_main() {
+    # Only relevant for the push subcommand
+    local _found_push=false
+    local _a
+    for _a in "$@"; do [[ "$_a" == "push" ]] && { _found_push=true; break; }; done
+    [[ "$_found_push" == false ]] && return 1
+
+    # If this is a deletion command, defer to GIT_PUSH_DELETE_REMOTE
+    local _da
+    for _da in "$@"; do
+        [[ "$_da" == "--delete" || "$_da" == "-d" ]] && return 1
+        [[ "$_da" == :?* ]] && return 1  # colon-prefix refspec = delete
+    done
+
+    local found_refspec=false
+    local a dest current_branch
+    for a in "$@"; do
+        [[ "$a" == "push" ]] && continue
+        [[ "$a" == --* ]] && continue
+        [[ "$a" =~ ^-[a-zA-Z]$ ]] && continue   # single-char flag like -u, -v
+
+        local spec="${a#+}"  # strip force-push prefix (+)
+
+        if [[ "$spec" == *:* ]]; then
+            # Refspec with explicit destination (src:dst or :dst)
+            dest="${spec##*:}"
+            dest="${dest#refs/heads/}"
+            found_refspec=true
+            # HEAD as destination resolves to current branch
+            if [[ "$dest" == "HEAD" ]]; then
+                current_branch=$(git symbolic-ref --short HEAD 2>/dev/null) || continue
+                dest="$current_branch"
+            fi
+            [[ -n "$dest" ]] && _cs_is_protected_branch "$dest" && return 0
+        else
+            dest="${spec#refs/heads/}"
+            # HEAD arg resolves to current branch
+            if [[ "$dest" == "HEAD" ]]; then
+                current_branch=$(git symbolic-ref --short HEAD 2>/dev/null) || continue
+                dest="$current_branch"
+                found_refspec=true
+                _cs_is_protected_branch "$dest" && return 0
+                continue
+            fi
+            # Simple name: could be remote OR branch — only flag if it's protected
+            if _cs_is_protected_branch "$dest"; then
+                found_refspec=true
+                return 0
+            fi
+        fi
+    done
+
+    # No explicit refspec — bare push uses tracking branch; check current branch
+    if [[ "$found_refspec" == false ]]; then
+        current_branch=$(git symbolic-ref --short HEAD 2>/dev/null) || return 1
+        _cs_is_protected_branch "$current_branch" && return 0
+    fi
+
+    return 1
+}
+
+# --- match_fn: detect remote branch deletion ---
+# Handles: git push --delete origin branch / git push origin :branch
+_cs_match_push_delete_remote() {
+    local a
+    for a in "$@"; do
+        [[ "$a" == "--delete" || "$a" == "-d" ]] && return 0
+        # Colon-prefix refspec = delete (e.g. :feature-branch)
+        [[ "$a" == :?* ]] && return 0
+    done
+    return 1
+}
+
+# --- match_fn: detect merge while currently on a protected branch ---
+# Excludes: --abort, --continue, --quit (those are resolution commands, not new merges)
+_cs_match_merge_on_main() {
+    # Only relevant for the merge subcommand
+    local _found_merge=false
+    local _a
+    for _a in "$@"; do [[ "$_a" == "merge" ]] && { _found_merge=true; break; }; done
+    [[ "$_found_merge" == false ]] && return 1
+
+    # First check we're on a protected branch
+    local current_branch
+    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null) || return 1
+    _cs_is_protected_branch "$current_branch" || return 1
+
+    # Exclude resolution subcommands — they're undoing a merge, not starting one
+    local a
+    for a in "$@"; do
+        [[ "$a" == "--abort" || "$a" == "--continue" || "$a" == "--quit" ]] && return 1
+    done
+
+    # Any other git merge while on protected branch = dangerous
+    return 0
+}
+
+# --- GIT_PUSH_MAIN: block direct push to main/master ---
+_rule GIT_PUSH_MAIN cmd="git" \
+    match_fn="_cs_match_push_to_main" \
+    block="Direct push to main/master bypasses PR review — use a branch and PR" \
+    bypass="--force-push-main"
+
+_fix GIT_PUSH_MAIN \
+    "gh pr create                    # Open a pull request from current branch" \
+    "git push origin HEAD            # Push current branch (not main)"
+
+# --- GIT_PUSH_DELETE_REMOTE: block remote branch deletion ---
+_rule GIT_PUSH_DELETE_REMOTE cmd="git" \
+    match_fn="_cs_match_push_delete_remote" \
+    block="Permanently deletes a remote branch — verify the branch is merged first" \
+    bypass="--force-remote-delete"
+
+_fix GIT_PUSH_DELETE_REMOTE \
+    "git branch --merged main        # Check if branch is already merged" \
+    "gh pr view <number>             # Confirm PR was merged before deleting"
+
+# --- GIT_PUSH_ALL_BRANCHES: block push --all and push --mirror ---
+_rule GIT_PUSH_ALL_BRANCHES cmd="git" match="push --all|push --mirror" \
+    block="Pushes ALL branches (including main) to remote — use targeted pushes instead" \
+    bypass="--force-push-all"
+
+_fix GIT_PUSH_ALL_BRANCHES \
+    "git push origin <branch>  # Push specific branch only"
+
+# --- GIT_MERGE_ON_MAIN: block git merge while on a protected branch ---
+_rule GIT_MERGE_ON_MAIN cmd="git" \
+    match_fn="_cs_match_merge_on_main" \
+    block="Merging directly into main/master bypasses PR review" \
+    bypass="--force-merge-main"
+
+_fix GIT_MERGE_ON_MAIN \
+    "git checkout -b <feature>   # Work on a feature branch instead" \
+    "gh pr create                # Open a PR from your feature branch"
+
 # --- mv in git repo (info only) ---
 _rule MV_GIT cmd="mv" context="git_repo" \
     info="Use git mv to preserve file history in the repository"

--- a/tests/command-safety/rules/git-agent-safety.bats
+++ b/tests/command-safety/rules/git-agent-safety.bats
@@ -1,0 +1,406 @@
+#!/usr/bin/env bats
+# =============================================================================
+# AGENT SAFETY GIT RULES - Tests
+# =============================================================================
+# Tests for the push-to-main, remote-delete, push-all, and merge-on-main
+# rules added to lib/command-safety/rules/git.sh
+# =============================================================================
+
+setup() {
+	export SHELL_CONFIG_DIR="$BATS_TEST_DIRNAME/../../.."
+	export COMMAND_SAFETY_DIR="$SHELL_CONFIG_DIR/lib/command-safety"
+
+	TEST_TEMP_DIR="$(mktemp -d)"
+	cd "$TEST_TEMP_DIR" || return 1
+
+	# Source engine prereqs
+	source "$COMMAND_SAFETY_DIR/engine/registry.sh"
+	source "$COMMAND_SAFETY_DIR/engine/display.sh"
+	source "$COMMAND_SAFETY_DIR/engine/wrapper.sh"
+	source "$COMMAND_SAFETY_DIR/engine/loader.sh"
+	source "$COMMAND_SAFETY_DIR/engine/matcher.sh"
+	source "$COMMAND_SAFETY_DIR/engine/utils.sh"
+	source "$COMMAND_SAFETY_DIR/engine/rule-helpers.sh"
+
+	# Source git rules (includes match_fn helpers + rules)
+	source "$COMMAND_SAFETY_DIR/rules/git.sh"
+
+	# Set up a real git repo so _in_git_repo and git symbolic-ref work
+	git init -q
+	git config user.email "test@test.com"
+	git config user.name "Test"
+	git commit -q --allow-empty -m "init"
+	# Ensure we're on main (older git defaults to master)
+	git checkout -q -B main 2>/dev/null || true
+}
+
+teardown() {
+	cd "$BATS_TEST_DIRNAME" || return 1
+	[[ -n "${TEST_TEMP_DIR:-}" ]] && /bin/rm -rf "$TEST_TEMP_DIR" 2>/dev/null || true
+}
+
+_reset_rule_registry() {
+	COMMAND_SAFETY_RULE_SUFFIXES=()
+	COMMAND_SAFETY_RULE_ID=()
+	COMMAND_SAFETY_RULE_ACTION=()
+	COMMAND_SAFETY_RULE_COMMAND=()
+	COMMAND_SAFETY_RULE_PATTERN=()
+	COMMAND_SAFETY_RULE_EMOJI=()
+	COMMAND_SAFETY_RULE_DESC=()
+	COMMAND_SAFETY_RULE_DOCS=()
+	COMMAND_SAFETY_RULE_BYPASS=()
+	COMMAND_SAFETY_RULE_ALTERNATIVES=()
+	COMMAND_SAFETY_RULE_EXEMPT=()
+	COMMAND_SAFETY_RULE_CONTEXT=()
+	COMMAND_SAFETY_RULE_MATCH_FN=()
+	_CS_CMD_RULES=()
+}
+
+# =============================================================================
+# Syntax checks
+# =============================================================================
+
+@test "git-agent-safety: git.sh is valid bash syntax" {
+	run bash -n "$COMMAND_SAFETY_DIR/rules/git.sh"
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Rule registration
+# =============================================================================
+
+@test "git-agent-safety: GIT_PUSH_MAIN rule is registered" {
+	[ -n "${COMMAND_SAFETY_RULE_ID[GIT_PUSH_MAIN]:-}" ]
+	[ "${COMMAND_SAFETY_RULE_ACTION[GIT_PUSH_MAIN]}" = "block" ]
+	[ "${COMMAND_SAFETY_RULE_COMMAND[GIT_PUSH_MAIN]}" = "git" ]
+}
+
+@test "git-agent-safety: GIT_PUSH_DELETE_REMOTE rule is registered" {
+	[ -n "${COMMAND_SAFETY_RULE_ID[GIT_PUSH_DELETE_REMOTE]:-}" ]
+	[ "${COMMAND_SAFETY_RULE_ACTION[GIT_PUSH_DELETE_REMOTE]}" = "block" ]
+}
+
+@test "git-agent-safety: GIT_PUSH_ALL_BRANCHES rule is registered" {
+	[ -n "${COMMAND_SAFETY_RULE_ID[GIT_PUSH_ALL_BRANCHES]:-}" ]
+	[ "${COMMAND_SAFETY_RULE_ACTION[GIT_PUSH_ALL_BRANCHES]}" = "block" ]
+}
+
+@test "git-agent-safety: GIT_MERGE_ON_MAIN rule is registered" {
+	[ -n "${COMMAND_SAFETY_RULE_ID[GIT_MERGE_ON_MAIN]:-}" ]
+	[ "${COMMAND_SAFETY_RULE_ACTION[GIT_MERGE_ON_MAIN]}" = "block" ]
+}
+
+@test "git-agent-safety: all new rules have bypass flags" {
+	[ -n "${COMMAND_SAFETY_RULE_BYPASS[GIT_PUSH_MAIN]:-}" ]
+	[ -n "${COMMAND_SAFETY_RULE_BYPASS[GIT_PUSH_DELETE_REMOTE]:-}" ]
+	[ -n "${COMMAND_SAFETY_RULE_BYPASS[GIT_PUSH_ALL_BRANCHES]:-}" ]
+	[ -n "${COMMAND_SAFETY_RULE_BYPASS[GIT_MERGE_ON_MAIN]:-}" ]
+}
+
+# =============================================================================
+# _cs_match_push_to_main — positive cases (should return 0 = match)
+# =============================================================================
+
+@test "push-to-main: blocks 'git push origin main'" {
+	run _cs_match_push_to_main push origin main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'git push origin master'" {
+	run _cs_match_push_to_main push origin master
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks '-u origin main'" {
+	run _cs_match_push_to_main push -u origin main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks '--set-upstream origin main'" {
+	run _cs_match_push_to_main push --set-upstream origin main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'origin HEAD:main' refspec" {
+	run _cs_match_push_to_main push origin HEAD:main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'origin feature:main' refspec" {
+	run _cs_match_push_to_main push origin feature:main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'origin feature:master' refspec" {
+	run _cs_match_push_to_main push origin feature:master
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'origin +main' force-push shorthand" {
+	run _cs_match_push_to_main push origin +main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'origin +HEAD:main' force-push refspec" {
+	run _cs_match_push_to_main push origin +HEAD:main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'origin refs/heads/main'" {
+	run _cs_match_push_to_main push origin refs/heads/main
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks bare 'git push' when on main branch" {
+	# setup already puts us on main
+	run _cs_match_push_to_main push
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'git push origin' (no branch) when on main" {
+	run _cs_match_push_to_main push origin
+	[ "$status" -eq 0 ]
+}
+
+@test "push-to-main: blocks 'origin HEAD' when HEAD is main" {
+	run _cs_match_push_to_main push origin HEAD
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# _cs_match_push_to_main — negative cases (should return 1 = no match)
+# =============================================================================
+
+@test "push-to-main: allows push to feature branch" {
+	git checkout -q -b feature/my-work 2>/dev/null
+	run _cs_match_push_to_main push origin feature/my-work
+	[ "$status" -eq 1 ]
+}
+
+@test "push-to-main: allows explicit feature refspec" {
+	run _cs_match_push_to_main push origin HEAD:feature/my-work
+	[ "$status" -eq 1 ]
+}
+
+@test "push-to-main: allows bare push when on feature branch" {
+	git checkout -q -b feature/agent-work 2>/dev/null
+	run _cs_match_push_to_main push
+	[ "$status" -eq 1 ]
+}
+
+@test "push-to-main: allows push with custom protected branches (not main)" {
+	COMMAND_SAFETY_PROTECTED_BRANCHES="production staging"
+	run _cs_match_push_to_main push origin main
+	[ "$status" -eq 1 ]
+	unset COMMAND_SAFETY_PROTECTED_BRANCHES
+}
+
+@test "push-to-main: custom COMMAND_SAFETY_PROTECTED_BRANCHES is respected" {
+	COMMAND_SAFETY_PROTECTED_BRANCHES="production"
+	run _cs_match_push_to_main push origin production
+	[ "$status" -eq 0 ]
+	unset COMMAND_SAFETY_PROTECTED_BRANCHES
+}
+
+# =============================================================================
+# _cs_match_push_to_main — bypass
+# =============================================================================
+
+@test "push-to-main: bypass flag --force-push-main is registered" {
+	[ "${COMMAND_SAFETY_RULE_BYPASS[GIT_PUSH_MAIN]}" = "--force-push-main" ]
+}
+
+# =============================================================================
+# _cs_match_push_delete_remote — positive cases
+# =============================================================================
+
+@test "push-delete-remote: blocks 'git push --delete origin branch'" {
+	run _cs_match_push_delete_remote push --delete origin my-branch
+	[ "$status" -eq 0 ]
+}
+
+@test "push-delete-remote: blocks 'git push -d origin branch'" {
+	run _cs_match_push_delete_remote push -d origin my-branch
+	[ "$status" -eq 0 ]
+}
+
+@test "push-delete-remote: blocks colon-prefix refspec 'origin :branch'" {
+	run _cs_match_push_delete_remote push origin :my-branch
+	[ "$status" -eq 0 ]
+}
+
+@test "push-delete-remote: blocks ':main' colon-prefix" {
+	run _cs_match_push_delete_remote push origin :main
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# _cs_match_push_delete_remote — negative cases
+# =============================================================================
+
+@test "push-delete-remote: allows normal push with branch" {
+	run _cs_match_push_delete_remote push origin main
+	[ "$status" -eq 1 ]
+}
+
+@test "push-delete-remote: allows push with refspec (no delete)" {
+	run _cs_match_push_delete_remote push origin HEAD:feature
+	[ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# GIT_PUSH_ALL_BRANCHES — pattern matching
+# =============================================================================
+
+@test "push-all: blocks 'git push --all'" {
+	run _check_command_rules git push --all
+	[ "$status" -eq 1 ]
+}
+
+@test "push-all: blocks 'git push --mirror'" {
+	run _check_command_rules git push --mirror
+	[ "$status" -eq 1 ]
+}
+
+@test "push-all: allows normal push" {
+	git checkout -q -b safe-branch 2>/dev/null
+	run _check_command_rules git push origin safe-branch
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# _cs_match_merge_on_main — positive cases
+# =============================================================================
+
+@test "merge-on-main: blocks 'git merge feature' when on main" {
+	# on main from setup
+	run _cs_match_merge_on_main merge feature/something
+	[ "$status" -eq 0 ]
+}
+
+@test "merge-on-main: blocks 'git merge --no-ff feature' when on main" {
+	run _cs_match_merge_on_main merge --no-ff feature/something
+	[ "$status" -eq 0 ]
+}
+
+@test "merge-on-main: blocks bare 'git merge' when on main" {
+	run _cs_match_merge_on_main merge
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# _cs_match_merge_on_main — negative cases
+# =============================================================================
+
+@test "merge-on-main: allows 'git merge feature' when on feature branch" {
+	git checkout -q -b feature/safe 2>/dev/null
+	run _cs_match_merge_on_main merge main
+	[ "$status" -eq 1 ]
+}
+
+@test "merge-on-main: allows '--abort' on main (resolving in-progress merge)" {
+	run _cs_match_merge_on_main merge --abort
+	[ "$status" -eq 1 ]
+}
+
+@test "merge-on-main: allows '--continue' on main" {
+	run _cs_match_merge_on_main merge --continue
+	[ "$status" -eq 1 ]
+}
+
+@test "merge-on-main: allows '--quit' on main" {
+	run _cs_match_merge_on_main merge --quit
+	[ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# Integration: _check_command_rules end-to-end
+# =============================================================================
+
+@test "integration: 'git push origin main' is blocked end-to-end" {
+	run _check_command_rules git push origin main
+	[ "$status" -eq 1 ]
+}
+
+@test "integration: 'git push origin feature-branch' is allowed end-to-end" {
+	git checkout -q -b feature-branch 2>/dev/null
+	run _check_command_rules git push origin feature-branch
+	[ "$status" -eq 0 ]
+}
+
+@test "integration: 'git push --delete origin branch' is blocked end-to-end" {
+	run _check_command_rules git push --delete origin old-feature
+	[ "$status" -eq 1 ]
+}
+
+@test "integration: 'git push --all' is blocked end-to-end" {
+	run _check_command_rules git push --all
+	[ "$status" -eq 1 ]
+}
+
+@test "integration: 'git merge feature' on main is blocked end-to-end" {
+	run _check_command_rules git merge feature/something
+	[ "$status" -eq 1 ]
+}
+
+@test "integration: 'git merge --abort' on main is allowed end-to-end" {
+	run _check_command_rules git merge --abort
+	[ "$status" -eq 0 ]
+}
+
+@test "integration: bypass flag --force-push-main allows push to main" {
+	run _check_command_rules git push origin main --force-push-main
+	[ "$status" -eq 0 ]
+}
+
+@test "integration: bypass flag --force-remote-delete allows remote delete" {
+	run _check_command_rules git push --delete origin branch --force-remote-delete
+	[ "$status" -eq 0 ]
+}
+
+@test "integration: bypass flag --force-merge-main allows merge on main" {
+	run _check_command_rules git merge feature/x --force-merge-main
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Agent simulation: common agent command patterns
+# =============================================================================
+
+@test "agent-sim: agent bare 'git push' on main is blocked" {
+	# Agent finishes work, runs git push without thinking
+	run _check_command_rules git push
+	[ "$status" -eq 1 ]
+}
+
+@test "agent-sim: agent 'git push -u origin main' is blocked" {
+	run _check_command_rules git push -u origin main
+	[ "$status" -eq 1 ]
+}
+
+@test "agent-sim: agent 'git push origin HEAD:refs/heads/main' is blocked" {
+	run _check_command_rules git push origin HEAD:refs/heads/main
+	[ "$status" -eq 1 ]
+}
+
+@test "agent-sim: agent 'git push origin +main' force push is blocked" {
+	run _check_command_rules git push origin +main
+	[ "$status" -eq 1 ]
+}
+
+@test "agent-sim: agent 'git push --mirror' is blocked" {
+	run _check_command_rules git push --mirror
+	[ "$status" -eq 1 ]
+}
+
+@test "agent-sim: agent on feature branch can push normally" {
+	git checkout -q -b feat/my-feature 2>/dev/null
+	run _check_command_rules git push origin feat/my-feature
+	[ "$status" -eq 0 ]
+}
+
+@test "agent-sim: agent on feature branch bare push is allowed" {
+	git checkout -q -b feat/my-feature 2>/dev/null
+	run _check_command_rules git push
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds 4 new git command-safety rules that prevent AI agents (and humans) from bypassing the PR workflow
- 57 bats tests, all passing
- All rules have bypass flags and respect `COMMAND_SAFETY_PROTECTED_BRANCHES`

## Rules added

| Rule | Blocks | Bypass |
|---|---|---|
| `GIT_PUSH_MAIN` | All forms of push to `main`/`master`: bare push, explicit branch, HEAD:main, feature:main, +main, refs/heads/main, --set-upstream | `--force-push-main` |
| `GIT_PUSH_DELETE_REMOTE` | `git push --delete origin <branch>`, `git push -d`, colon-prefix refspecs (`:branch`) | `--force-remote-delete` |
| `GIT_PUSH_ALL_BRANCHES` | `git push --all`, `git push --mirror` | `--force-push-all` |
| `GIT_MERGE_ON_MAIN` | `git merge` while on a protected branch (but NOT --abort/--continue/--quit) | `--force-merge-main` |

## Agent attack vectors covered

```bash
git push                          # bare push on main → BLOCKED
git push origin main              # explicit → BLOCKED
git push -u origin main           # with -u → BLOCKED
git push origin HEAD:main         # refspec → BLOCKED
git push origin feature:main      # destination refspec → BLOCKED
git push origin +main             # force prefix → BLOCKED
git push origin HEAD:refs/heads/main  # full ref → BLOCKED
git push --all                    # all branches → BLOCKED
git push --mirror                 # mirror → BLOCKED
git push --delete origin branch   # remote delete → BLOCKED
git push origin :branch           # colon delete → BLOCKED
git merge feature  (on main)      # merge to main → BLOCKED
git merge --abort  (on main)      # safe → ALLOWED ✓
git push origin feature-branch    # feature branch → ALLOWED ✓
git push  (on feature branch)     # bare push off main → ALLOWED ✓
```

## Configuration

```bash
# Override protected branches (default: main master)
export COMMAND_SAFETY_PROTECTED_BRANCHES="main master production"
```

## Test plan
- [x] 57 bats tests covering all match_fn variants, negatives, bypasses, and agent simulation patterns
- [x] Pre-commit hooks passed
- [x] Subcommand guards prevent cross-rule false positives (critical bug found and fixed during testing)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)