### PR TITLE
fix: 1Password SSH agent opt-in + document missing install tools

### DIFF
--- a/config/zshenv
+++ b/config/zshenv
@@ -4,6 +4,9 @@
 # Environment variables for all zsh sessions (loaded before .zshrc)
 # =============================================================================
 
+# 1Password SSH agent — set to "true" to enable, "false" to disable, "auto" to silently skip
+# export SHELL_CONFIG_1PASSWORD_SSH=auto
+
 # Cargo (Rust) - only if installed
 [[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
 

--- a/lib/core/loaders/ssh.sh
+++ b/lib/core/loaders/ssh.sh
@@ -13,16 +13,23 @@ _1P_SSH_AGENT_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/ag
 _load_ssh() {
     local debug=${SHELL_DEBUG:-0}
 
+    # Opt out: export SHELL_CONFIG_1PASSWORD_SSH=false in ~/.zshenv or before init
+    local use_1p="${SHELL_CONFIG_1PASSWORD_SSH:-auto}"
+    [[ "$use_1p" == "false" ]] && return 0
+
     if [[ -S "$_1P_SSH_AGENT_SOCK" ]]; then
         export SSH_AUTH_SOCK="$_1P_SSH_AGENT_SOCK"
         [[ $debug -eq 1 ]] && echo "1Password SSH agent configured"
         return 0
     fi
 
-    echo "⚠️  WARNING: 1Password SSH agent socket not found" >&2
-    echo "ℹ️  WHY: SSH keys will not be available for git/ssh operations" >&2
-    echo "💡 FIX: Enable the SSH agent in 1Password and ensure the app is running" >&2
-    echo "💡 FIX: Expected socket: $_1P_SSH_AGENT_SOCK" >&2
+    # Only warn if user explicitly enabled 1Password SSH (auto = silent skip)
+    if [[ "$use_1p" == "true" ]]; then
+        echo "⚠️  WARNING: 1Password SSH agent socket not found" >&2
+        echo "ℹ️  WHY: SSH keys will not be available for git/ssh operations" >&2
+        echo "💡 FIX: Enable the SSH agent in 1Password and ensure the app is running" >&2
+        echo "💡 FIX: Expected socket: $_1P_SSH_AGENT_SOCK" >&2
+    fi
     return 0
 }
 


### PR DESCRIPTION
## Summary

- **1Password SSH** is now opt-in instead of mandatory — no more warning spam for users who don't use 1Password
- **Document missing install tools** in the issue so the install script can be updated

## Changes

### `lib/core/loaders/ssh.sh`

New `SHELL_CONFIG_1PASSWORD_SSH` env var (set in `~/.zshenv` before `.zshrc` runs):

| Value | Behaviour |
|---|---|
| `auto` (default) | Use 1Password if socket exists; silently skip if not |
| `true` | Use 1Password; warn loudly if socket is missing |
| `false` | Skip entirely |

### `config/zshenv`

Added commented-out opt-in example so users know the flag exists.

## Before / After

**Before:** Every new shell on a machine without 1Password printed:
```
⚠️  WARNING: 1Password SSH agent socket not found
ℹ️  WHY: SSH keys will not be available for git/ssh operations
💡 FIX: Enable the SSH agent in 1Password and ensure the app is running
```

**After:** Silent on machines without 1Password. Users who explicitly set
`SHELL_CONFIG_1PASSWORD_SSH=true` still get the warning.

## Related

Closes #7 (SSH config overwrite breaks existing keys)
Also relevant to #8 (missing tools in install.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)