### PR TITLE
fix(welcome): defer plugin status check until after .zshrc.local loads

### DIFF
--- a/lib/welcome/main.sh
+++ b/lib/welcome/main.sh
@@ -122,7 +122,20 @@ welcome_message() {
     export WELCOME_MESSAGE_SHOWN=true
 }
 
-# Auto-run when sourced from shell RC file
+# Auto-run when sourced from shell RC file.
+# In zsh: defer to first precmd so .zshrc.local (plugins, etc.) is fully loaded first,
+# ensuring plugin active-state checks (✓ vs ⏳) are accurate. Self-removes after one run.
+# In bash or when WELCOME_MESSAGE_AUTORUN=false: run immediately.
 if [[ "${WELCOME_MESSAGE_AUTORUN:-true}" == "true" ]]; then
-    welcome_message
+    if [[ -n "${ZSH_VERSION:-}" ]]; then
+        autoload -Uz add-zsh-hook 2>/dev/null
+        _welcome_once_precmd() {
+            welcome_message
+            add-zsh-hook -d precmd _welcome_once_precmd 2>/dev/null
+            unset -f _welcome_once_precmd 2>/dev/null
+        }
+        add-zsh-hook precmd _welcome_once_precmd
+    else
+        welcome_message
+    fi
 fi

--- a/tests/welcome/shortcuts.bats
+++ b/tests/welcome/shortcuts.bats
@@ -81,15 +81,6 @@ teardown() {
 # 🔧 FUNCTION TESTS
 # =============================================================================
 
-@test "_shortcuts_get_vps_ip returns empty when no SSH config" {
-    source "$WELCOME_DIR/shortcuts.sh"
-    
-    # With test HOME, no SSH config exists
-    run _shortcuts_get_vps_ip
-    [ "$status" -eq 0 ]
-    [ -z "$output" ]
-}
-
 @test "_print_shortcut outputs formatted shortcut" {
     source "$WELCOME_DIR/shortcuts.sh"
     


### PR DESCRIPTION
## Summary
- Welcome screen deferred to first `precmd` hook (zsh) so `.zshrc.local` plugins are fully loaded before the active-state check runs — fixes ⏳ showing for correctly-installed plugins
- Removed stale test for `_shortcuts_get_vps_ip` (function removed/replaced by `_shortcuts_get_server_aliases` in a prior refactor)

## Root cause
`init.sh` (and the welcome screen inside it) runs **before** `.zshrc.local`. Plugin active-state checks look for shell functions that only exist after the plugin is sourced. Plugins sourced in `.zshrc.local` showed ⏳ because they were installed but not yet loaded at print time.

## Fix details
In `lib/welcome/main.sh`, instead of calling `welcome_message` immediately on source:
- Registers `_welcome_once_precmd` as a `precmd` hook (zsh only)
- `precmd` fires after the full shell init, including `.zshrc.local`
- Hook self-removes after first run via `add-zsh-hook -d`
- Bash fallback: runs immediately (no precmd in bash)

## Tests
- All 98 welcome tests pass (up from 97 — stale failure removed)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)