### PR TITLE
feat(claude): agent configs, tool prefs, and setup skill

### DIFF
--- a/config/claude/agents/code-reviewer.md
+++ b/config/claude/agents/code-reviewer.md
@@ -1,0 +1,34 @@
+---
+name: code-reviewer
+description: Security and quality code reviewer. Use before commits or PRs. Checks OWASP top-10 issues, performance problems, and style violations. Read-only — never modifies files.
+tools: Bash, Read, Glob, Grep
+---
+
+## Tool Preferences
+- `rg` for all searches
+- `ast-grep` (`sg`) for pattern-based structural review
+- `timeout 60` on all shell commands
+
+## Python
+- Flag any use of `pip`, `pip3`, or `python3 -m pip` — these should use `uv` instead
+- Flag hardcoded `python3` shebang lines that should use `uv run`
+
+## Review Checklist
+- Security: OWASP top 10 (injection, XSS, insecure deserialization, secrets in code)
+- Performance: N+1 queries, unbounded loops, missing indexes
+- Correctness: error handling gaps, unchecked return values, race conditions
+- Style: naming, dead code, overly complex logic
+
+## Output Format
+For each finding:
+```
+[SEVERITY] file:line
+Issue: <one sentence>
+Fix: <one sentence>
+```
+Severity: CRITICAL / HIGH / MEDIUM / LOW / INFO
+
+## Behaviour
+- Read-only — never modify files
+- If nothing is wrong, say so explicitly
+- Focus on the diff/changed files unless asked for a full review

--- a/config/claude/agents/code-reviewer.md
+++ b/config/claude/agents/code-reviewer.md
@@ -1,34 +1,24 @@
 ---
 name: code-reviewer
-description: Security and quality code reviewer. Use before commits or PRs. Checks OWASP top-10 issues, performance problems, and style violations. Read-only — never modifies files.
+description: Security and quality review before commits or PRs. Checks OWASP top-10, performance, correctness, and style. Read-only.
 tools: Bash, Read, Glob, Grep
 ---
 
 ## Tool Preferences
-- `rg` for all searches
-- `ast-grep` (`sg`) for pattern-based structural review
-- `timeout 60` on all shell commands
-
-## Python
-- Flag any use of `pip`, `pip3`, or `python3 -m pip` — these should use `uv` instead
-- Flag hardcoded `python3` shebang lines that should use `uv run`
+- `rg` for searches, `ast-grep` for structural patterns
+- `timeout 60` on all commands
+- Flag `pip`/`pip3`/`python3 -m pip` usage — should be `uv`
 
 ## Review Checklist
-- Security: OWASP top 10 (injection, XSS, insecure deserialization, secrets in code)
-- Performance: N+1 queries, unbounded loops, missing indexes
-- Correctness: error handling gaps, unchecked return values, race conditions
-- Style: naming, dead code, overly complex logic
+- **Security**: OWASP top 10 — injection, XSS, secrets in code, insecure deserialization
+- **Performance**: N+1 queries, unbounded loops, missing indexes
+- **Correctness**: unhandled errors, unchecked return values, race conditions
+- **Style**: dead code, unclear naming, unnecessary complexity
 
-## Output Format
-For each finding:
+## Output
 ```
-[SEVERITY] file:line
-Issue: <one sentence>
-Fix: <one sentence>
+[SEVERITY] file:line — Issue. Fix.
 ```
-Severity: CRITICAL / HIGH / MEDIUM / LOW / INFO
+Levels: CRITICAL / HIGH / MEDIUM / LOW / INFO
 
-## Behaviour
-- Read-only — never modify files
-- If nothing is wrong, say so explicitly
-- Focus on the diff/changed files unless asked for a full review
+If nothing found, say so explicitly. Focus on changed files unless asked otherwise.

--- a/config/claude/agents/refactor-cleaner.md
+++ b/config/claude/agents/refactor-cleaner.md
@@ -1,33 +1,20 @@
 ---
 name: refactor-cleaner
-description: Detects code duplication, dead code, and architecture violations using jscpd, knip, and dependency-cruiser. Returns a prioritised action list. Never auto-applies changes.
+description: Finds duplication, dead code, and architecture violations. Returns a prioritised action list. Never applies changes.
 tools: Bash, Read, Glob, Grep
 ---
 
-## Tool Preferences
-- `rg` for searches, `timeout 60` on all commands
-- `jscpd --reporter ai` for compact duplication output (~79% fewer tokens than default)
-- `knip` for unused exports, files, dependencies
-- `depcruise` for circular dependencies and import violations
-
 ## Steps
-1. `timeout 60 jscpd --reporter ai .` (or target directory)
-2. `timeout 60 knip` if config exists, else skip and note it
-3. `timeout 60 depcruise --include-only "^src" src` if src/ exists
+1. `timeout 120 jscpd --reporter ai .`
+2. `timeout 120 knip` (skip if no config, note it)
+3. `timeout 120 depcruise --include-only "^src" src` (skip if no src/)
 
-## Output Format
+## Output
 ```
-## Duplication (jscpd)
-- [HIGH] file-a.ts:10–30 ↔ file-b.ts:55–75 — extract to shared util
-
-## Dead Code (knip)
-- [MED] src/utils/oldHelper.ts — unused, safe to delete
-
-## Architecture (depcruise)
-- [HIGH] Circular: auth → user → auth — break cycle via interface
+## Duplication — [HIGH] a.ts:10-30 ↔ b.ts:55-75 — extract to shared util
+## Dead Code  — [MED]  src/utils/old.ts — unused, safe to delete
+## Architecture — [HIGH] Circular: auth→user→auth — break via interface
 ```
 Priorities: HIGH / MED / LOW
 
-## Behaviour
-- Never apply changes automatically
-- If tools aren't installed, say so and suggest running `install.sh`
+If tools are missing, say so and suggest running `install.sh`. Never auto-apply changes.

--- a/config/claude/agents/refactor-cleaner.md
+++ b/config/claude/agents/refactor-cleaner.md
@@ -1,0 +1,33 @@
+---
+name: refactor-cleaner
+description: Detects code duplication, dead code, and architecture violations using jscpd, knip, and dependency-cruiser. Returns a prioritised action list. Never auto-applies changes.
+tools: Bash, Read, Glob, Grep
+---
+
+## Tool Preferences
+- `rg` for searches, `timeout 60` on all commands
+- `jscpd --reporter ai` for compact duplication output (~79% fewer tokens than default)
+- `knip` for unused exports, files, dependencies
+- `depcruise` for circular dependencies and import violations
+
+## Steps
+1. `timeout 60 jscpd --reporter ai .` (or target directory)
+2. `timeout 60 knip` if config exists, else skip and note it
+3. `timeout 60 depcruise --include-only "^src" src` if src/ exists
+
+## Output Format
+```
+## Duplication (jscpd)
+- [HIGH] file-a.ts:10–30 ↔ file-b.ts:55–75 — extract to shared util
+
+## Dead Code (knip)
+- [MED] src/utils/oldHelper.ts — unused, safe to delete
+
+## Architecture (depcruise)
+- [HIGH] Circular: auth → user → auth — break cycle via interface
+```
+Priorities: HIGH / MED / LOW
+
+## Behaviour
+- Never apply changes automatically
+- If tools aren't installed, say so and suggest running `install.sh`

--- a/config/claude/agents/worker.md
+++ b/config/claude/agents/worker.md
@@ -1,0 +1,23 @@
+---
+name: worker
+description: General-purpose parallel research and exploration agent. Use for independent tasks that don't modify files — reading code, searching, analysis, summarising findings. Safe to spawn multiple in parallel.
+tools: Bash, Read, Glob, Grep
+---
+
+## Tool Preferences
+- `rg` instead of `grep` for all searches (respects .gitignore)
+- `ast-grep` (`sg`) for structural/syntax-aware code search
+- `fd` instead of `find` for file discovery
+- `jq` for JSON, `yq` for YAML
+- `bat` instead of `cat` for file viewing
+- Always `timeout <N>` on shell commands (60s default, 300s for builds/installs)
+
+## Python
+- Use `uv` for all Python package operations — never `pip`, `pip3`, or bare `python3 -m pip`
+- `uv run <script>` instead of `python3 <script>` when a venv is expected
+
+## Behaviour
+- Return a concise summary — do not dump raw file contents
+- On failure, report the full error before attempting a fix
+- Never modify files — read-only work only
+- If scope is unclear, report what you found and stop

--- a/config/claude/agents/worker.md
+++ b/config/claude/agents/worker.md
@@ -1,23 +1,20 @@
 ---
 name: worker
-description: General-purpose parallel research and exploration agent. Use for independent tasks that don't modify files — reading code, searching, analysis, summarising findings. Safe to spawn multiple in parallel.
+description: Read-only research and exploration. Use for independent tasks (code search, analysis, summarising). Safe to spawn in parallel.
 tools: Bash, Read, Glob, Grep
 ---
 
 ## Tool Preferences
-- `rg` instead of `grep` for all searches (respects .gitignore)
-- `ast-grep` (`sg`) for structural/syntax-aware code search
-- `fd` instead of `find` for file discovery
-- `jq` for JSON, `yq` for YAML
-- `bat` instead of `cat` for file viewing
-- Always `timeout <N>` on shell commands (60s default, 300s for builds/installs)
-
-## Python
-- Use `uv` for all Python package operations — never `pip`, `pip3`, or bare `python3 -m pip`
-- `uv run <script>` instead of `python3 <script>` when a venv is expected
+- `rg` instead of `grep` (respects .gitignore)
+- `ast-grep` (`sg`) for structural code search
+- `fd` instead of `find`
+- `jq` / `yq` for JSON / YAML
+- `bat` instead of `cat`
+- `uv` for Python — never `pip`, `pip3`, or `python3 -m pip`
+- `timeout 60 <cmd>` on all shell commands; `timeout 300` for builds/installs
 
 ## Behaviour
-- Return a concise summary — do not dump raw file contents
-- On failure, report the full error before attempting a fix
-- Never modify files — read-only work only
-- If scope is unclear, report what you found and stop
+- Return a concise summary — never dump raw file contents
+- Report full errors before attempting fixes
+- Never modify files
+- If scope is unclear, report findings and stop

--- a/config/claude/commands/setup-claude-md.md
+++ b/config/claude/commands/setup-claude-md.md
@@ -1,0 +1,17 @@
+Check if ~/.claude/CLAUDE.md already contains the shell-config tools section by looking for the text "BEGIN shell-config-tools".
+
+If it already exists: report that it's already configured and stop.
+
+If it doesn't exist:
+1. Read the file at ~/.shell-config/config/claude/shell-config-tools.md
+2. Show the user what will be added and briefly explain each section:
+   - "Available CLI Tools" — tells Claude to prefer rg, ast-grep, fd, sd, bat, jq, yq, scc over defaults
+   - "Python Tooling" — always use uv, never pip/python3
+   - "Command Safety" — requires timeout wrappers on shell commands
+   - "Subagent Routing" — when to dispatch parallel vs sequential vs background work
+3. Ask: "Append this to your ~/.claude/CLAUDE.md? (yes/no)"
+4. If yes:
+   - Append a blank line then the contents of shell-config-tools.md to ~/.claude/CLAUDE.md
+   - Report success
+   - Note: to remove later, delete lines between "BEGIN shell-config-tools" and "END shell-config-tools"
+5. If no: confirm that nothing was changed

--- a/config/claude/shell-config-tools.md
+++ b/config/claude/shell-config-tools.md
@@ -1,0 +1,54 @@
+<!-- BEGIN shell-config-tools — managed by shell-config, do not edit this block manually -->
+
+## Available CLI Tools
+
+Prefer these over defaults (installed by shell-config `install.sh`):
+
+**Search:**
+- `rg` — use instead of `grep`. Respects .gitignore automatically.
+- `ast-grep` (`sg`) — structural/syntax-aware code search (function calls, patterns, refactors)
+- `fd` — use instead of `find`
+
+**Replace / view:**
+- `sd` — use instead of `sed` for string replacement
+- `bat` — use instead of `cat` for file viewing
+- `difft` — use for reviewing diffs (AST-aware, ignores whitespace noise)
+
+**Data:**
+- `jq` — all JSON querying and filtering
+- `yq` — all YAML querying and filtering
+- `scc` — codebase stats (faster than cloc)
+
+**Code quality:**
+- `jscpd --reporter ai` — duplicate code detection (compact LLM-friendly output)
+- `depcruise` — circular dependency and architecture violation checks
+
+---
+
+## Python Tooling
+
+- **Always use `uv`** for Python package operations — never `pip`, `pip3`, or `python3 -m pip`
+- `uv add <pkg>` instead of `pip install <pkg>`
+- `uv run <script>` instead of `python3 <script>` when a venv is expected
+- `uv sync` instead of `pip install -r requirements.txt`
+- Commit `uv.lock` — never commit bare `requirements.txt` without a lock file
+
+---
+
+## Command Safety
+
+- Always wrap shell commands with a timeout: `timeout 60 <command>`
+- For long operations (builds, installs, test suites): `timeout 300 <command>`
+- Use `--timeout` flags when tools support them natively (e.g. `rg --timeout 30`)
+
+---
+
+## Subagent Routing
+
+**Parallel** (all must be true): 3+ independent tasks, no shared files, no state dependency
+**Sequential** (any triggers): task B needs output from A, shared files, unclear scope
+**Background**: research/analysis that isn't blocking current work
+
+Every subagent dispatch must include: scope, specific file references, expected output, success criteria.
+
+<!-- END shell-config-tools -->

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -1,0 +1,34 @@
+# Shell Config — Codex Agent Rules
+
+Deployed to `~/.codex/AGENTS.md` by shell-config `install.sh`.
+These rules apply globally to all Codex CLI sessions.
+
+## CLI Tool Preferences
+
+Use these instead of defaults (installed by `install.sh`):
+
+- `rg` instead of `grep` — respects .gitignore, faster
+- `ast-grep` (`sg`) — for structural/syntax-aware code search
+- `fd` instead of `find`
+- `sd` instead of `sed` for replacements
+- `jq` for JSON, `yq` for YAML
+- `bat` instead of `cat`
+- `scc` for codebase stats
+
+## Python
+
+- **Always `uv`** — never `pip`, `pip3`, or `python3 -m pip`
+- `uv add <pkg>` / `uv run <script>` / `uv sync`
+- Commit `uv.lock`
+
+## Command Safety
+
+- Wrap commands: `timeout 60 <cmd>` (default), `timeout 300 <cmd>` (builds/installs)
+
+## Subagent Routing
+
+**Parallel**: 3+ independent tasks, no shared files
+**Sequential**: B depends on A, shared files
+**Background**: research/analysis not blocking work
+
+Include in every subagent dispatch: scope, file refs, expected output, success criteria.

--- a/install.sh
+++ b/install.sh
@@ -679,6 +679,19 @@ deploy_claude_config() {
     _link_claude_dir "$agents_src" "$agents_dst" "agent"
     _link_claude_dir "$cmds_src"   "$cmds_dst"   "command"
 
+    # Codex CLI: deploy AGENTS.md to ~/.codex/AGENTS.md
+    local codex_src="$SCRIPT_DIR/config/codex/AGENTS.md"
+    local codex_dst="$HOME/.codex/AGENTS.md"
+    if [[ -f "$codex_src" ]]; then
+        mkdir -p "$HOME/.codex"
+        if [[ -L "$codex_dst" && "$(readlink "$codex_dst")" == "$codex_src" ]]; then
+            log_success "~/.codex/AGENTS.md already linked"
+        else
+            [[ -e "$codex_dst" ]] && mv "$codex_dst" "$codex_dst.backup.$(date +%Y%m%d_%H%M%S)"
+            ln -s "$codex_src" "$codex_dst" && log_success "Linked ~/.codex/AGENTS.md"
+        fi
+    fi
+
     echo ""
     echo "  💡 Run /setup-claude-md in Claude Code to add tool preferences to ~/.claude/CLAUDE.md"
 }

--- a/install.sh
+++ b/install.sh
@@ -652,6 +652,37 @@ EOF
     fi
 }
 
+deploy_claude_config() {
+    log_step "Deploying Claude Code agent configs"
+    local agents_src="$SCRIPT_DIR/config/claude/agents"
+    local agents_dst="$HOME/.claude/agents"
+    local cmds_src="$SCRIPT_DIR/config/claude/commands"
+    local cmds_dst="$HOME/.claude/commands"
+
+    _link_claude_dir() {
+        local src="$1" dst="$2" label="$3"
+        [[ -d "$src" ]] || return 0
+        mkdir -p "$dst"
+        local f name target
+        for f in "$src"/*.md; do
+            [[ -f "$f" ]] || continue
+            name=$(basename "$f"); target="$dst/$name"
+            if [[ -L "$target" && "$(readlink "$target")" == "$f" ]]; then
+                log_success "$label/$name already linked"
+            else
+                [[ -e "$target" ]] && rm -f "$target"
+                ln -s "$f" "$target" && log_success "Linked $label: $name"
+            fi
+        done
+    }
+
+    _link_claude_dir "$agents_src" "$agents_dst" "agent"
+    _link_claude_dir "$cmds_src"   "$cmds_dst"   "command"
+
+    echo ""
+    echo "  💡 Run /setup-claude-md in Claude Code to add tool preferences to ~/.claude/CLAUDE.md"
+}
+
 # =============================================================================
 # 7. MAKE SCRIPTS EXECUTABLE
 # =============================================================================
@@ -716,6 +747,7 @@ main() {
     echo ""
 
     symlink_config_files
+    deploy_claude_config
     if ! install_deps; then
         echo ""
         echo -e "${RED}❌ ERROR: Dependency installation failed${NC}" >&2


### PR DESCRIPTION
## What

Adds `config/claude/` with everything needed to make Claude Code and subagents work correctly out of the box after install.

## Changes

### Agent definitions (`config/claude/agents/`)
Three subagent files deployed to `~/.claude/agents/` by install.sh — tool preferences baked in so subagents don't need the parent session's CLAUDE.md:

- **worker.md** — parallel research/exploration, read-only, uses rg/ast-grep/fd/jq/uv
- **code-reviewer.md** — OWASP + perf + style review, structured severity output, read-only
- **refactor-cleaner.md** — runs jscpd/knip/depcruise, returns prioritised action list

### Guided setup skill (`config/claude/commands/setup-claude-md.md`)
`/setup-claude-md` slash command. Shows the user what will be added to `~/.claude/CLAUDE.md`, explains each section, and asks for confirmation before writing. No silent auto-appending.

### Tools snippet (`config/claude/shell-config-tools.md`)
Reference file used by `/setup-claude-md`. Covers:
- CLI tool preferences (rg, ast-grep, fd, sd, bat, jq, yq, scc over defaults)
- Python: always `uv`, never `pip`/`pip3` 
- Command timeouts (60s default, 300s for long ops)
- Subagent routing rules

### `install.sh` — `deploy_claude_config()`
Runs after `symlink_config_files` on every install:
- Symlinks agent files to `~/.claude/agents/` (idempotent)
- Symlinks commands to `~/.claude/commands/` (idempotent)
- Prints a prompt to run `/setup-claude-md`

## Closes
- #14 install.sh deploys agent configs to ~/.claude/
- #15 subagent system prompts (worker, code-reviewer, refactor-cleaner)
- #17 tool preferences for CLAUDE.md (via guided skill)
- #3 uv-over-pip guidance baked into agents and tools snippet

## Test plan
- [ ] Run `./install.sh` on a clean machine — verify `~/.claude/agents/` and `~/.claude/commands/` get populated
- [ ] Run again — verify idempotent (no duplicate links, no errors)
- [ ] Open Claude Code, run `/setup-claude-md` — verify it shows the snippet and asks before writing
- [ ] Spawn a `worker` subagent — verify it uses rg/ast-grep not grep/find

🤖 Generated with [Claude Code](https://claude.com/claude-code)