### PR TITLE
feat(command-safety): per-manager ALLOW_* env vars for package managers

### DIFF
--- a/lib/command-safety/rules/package-managers.sh
+++ b/lib/command-safety/rules/package-managers.sh
@@ -1,50 +1,71 @@
 #!/usr/bin/env bash
 # =============================================================================
-# ⚠️ PACKAGE MANAGER RULES
+# package-managers.sh - Package manager safety rules
 # =============================================================================
 # Safety rules for package managers: npm/yarn/pnpm (blocked — use bun),
 # pip/pip3/python/python3 (ALL blocked — use uv), brew, composer, go, cargo, bun.
 # Special matching:
 #   BREW_UNINSTALL - exempt="--zap" (so it doesn't trigger when --zap variant should)
+#
+# Disable all rules in this file:
+#   export COMMAND_SAFETY_DISABLE_PACKAGE_MANAGERS=true
+#
+# Allow individual managers (overrides block for that tool only):
+#   export COMMAND_SAFETY_ALLOW_NPM=true    # unblock npm
+#   export COMMAND_SAFETY_ALLOW_NPX=true    # unblock npx
+#   export COMMAND_SAFETY_ALLOW_YARN=true   # unblock yarn
+#   export COMMAND_SAFETY_ALLOW_PNPM=true   # unblock pnpm
+#   export COMMAND_SAFETY_ALLOW_PIP=true    # unblock pip/pip3 (python/python3 still blocked)
+#   export COMMAND_SAFETY_ALLOW_PYTHON=true # unblock python/python3 direct invocation
+#
+# Set allow flags before shell-config is sourced, e.g. in ~/.zshrc.local.
 # =============================================================================
 
 # shellcheck disable=SC2034
 
 # --- npm (blocked — use bun) ---
-_rule NPM cmd="npm" \
-    block="Use bun instead — this project uses bun exclusively" \
-    bypass="--force-npm" docs="https://bun.sh/docs"
+if [[ "${COMMAND_SAFETY_ALLOW_NPM:-}" != "true" ]]; then
+    _rule NPM cmd="npm" \
+        block="Use bun instead — this project uses bun exclusively" \
+        bypass="--force-npm" docs="https://bun.sh/docs"
 
-_fix NPM \
-    "bun install     # Instead of: npm install" \
-    "bun add <pkg>   # Instead of: npm install <pkg>" \
-    "bunx <cmd>      # Instead of: npx <cmd>"
+    _fix NPM \
+        "bun install     # Instead of: npm install" \
+        "bun add <pkg>   # Instead of: npm install <pkg>" \
+        "bunx <cmd>      # Instead of: npx <cmd>"
+fi
 
 # --- npx (blocked — use bunx) ---
-_rule NPX cmd="npx" \
-    block="Use bunx instead of npx" \
-    fix="bunx <package>" \
-    bypass="--force-npx" docs="https://bun.sh/docs"
+if [[ "${COMMAND_SAFETY_ALLOW_NPX:-}" != "true" ]]; then
+    _rule NPX cmd="npx" \
+        block="Use bunx instead of npx" \
+        fix="bunx <package>" \
+        bypass="--force-npx" docs="https://bun.sh/docs"
+fi
 
 # --- yarn (blocked — use bun) ---
-_rule YARN cmd="yarn" \
-    block="Use bun instead of yarn" \
-    bypass="--force-yarn" docs="https://bun.sh/docs"
+if [[ "${COMMAND_SAFETY_ALLOW_YARN:-}" != "true" ]]; then
+    _rule YARN cmd="yarn" \
+        block="Use bun instead of yarn" \
+        bypass="--force-yarn" docs="https://bun.sh/docs"
 
-_fix YARN \
-    "bun install       # Instead of: yarn install" \
-    "bun add <pkg>     # Instead of: yarn add <pkg>" \
-    "bun run <script>  # Instead of: yarn run <script>"
+    _fix YARN \
+        "bun install       # Instead of: yarn install" \
+        "bun add <pkg>     # Instead of: yarn add <pkg>" \
+        "bun run <script>  # Instead of: yarn run <script>"
+fi
 
 # --- pnpm (blocked — use bun) ---
-_rule PNPM cmd="pnpm" \
-    block="Use bun instead of pnpm" \
-    bypass="--force-pnpm"
+if [[ "${COMMAND_SAFETY_ALLOW_PNPM:-}" != "true" ]]; then
+    _rule PNPM cmd="pnpm" \
+        block="Use bun instead of pnpm" \
+        bypass="--force-pnpm"
 
-_fix PNPM \
-    "bun install   # Instead of: pnpm install" \
-    "bun add <pkg> # Instead of: pnpm add <pkg>" \
-    "bunx <pkg>    # Instead of: pnpm dlx <pkg>"
+    _fix PNPM \
+        "bun install   # Instead of: pnpm install" \
+        "bun add <pkg> # Instead of: pnpm add <pkg>" \
+        "bunx <pkg>    # Instead of: pnpm dlx <pkg>"
+fi
 
 # =============================================================================
 # 🐍 UV ENFORCEMENT: pip/pip3/python/python3 → uv
@@ -55,69 +76,73 @@ _fix PNPM \
 # so users get the most helpful message for pip-specific commands.
 # =============================================================================
 
-# --- pip (blocked — use uv) ---
-_rule PIP cmd="pip" \
-    block="Use uv instead of pip — 10-100x faster with automatic venv management" \
-    bypass="--force-pip" docs="https://docs.astral.sh/uv/"
+# --- pip/pip3 and python -m pip (blocked — use uv) ---
+if [[ "${COMMAND_SAFETY_ALLOW_PIP:-}" != "true" ]]; then
 
-_fix PIP \
-    "uv pip install <package>  # Drop-in pip replacement (10-100x faster)" \
-    "uv add <package>          # Add to project dependencies (pyproject.toml)" \
-    "uvx <command>             # Run CLI tools without installing (like pipx)"
+    _rule PIP cmd="pip" \
+        block="Use uv instead of pip — 10-100x faster with automatic venv management" \
+        bypass="--force-pip" docs="https://docs.astral.sh/uv/"
 
-# --- pip3 (blocked — use uv) ---
-_rule PIP3 cmd="pip3" \
-    block="Use uv instead of pip3 — uv handles Python 3 automatically" \
-    bypass="--force-pip3" docs="https://docs.astral.sh/uv/"
+    _fix PIP \
+        "uv pip install <package>  # Drop-in pip replacement (10-100x faster)" \
+        "uv add <package>          # Add to project dependencies (pyproject.toml)" \
+        "uvx <command>             # Run CLI tools without installing (like pipx)"
 
-_fix PIP3 \
-    "uv pip install <package>  # uv selects correct Python version automatically" \
-    "uv add <package>          # Add to project dependencies (pyproject.toml)" \
-    "uvx <command>             # Run CLI tools without installing"
+    _rule PIP3 cmd="pip3" \
+        block="Use uv instead of pip3 — uv handles Python 3 automatically" \
+        bypass="--force-pip3" docs="https://docs.astral.sh/uv/"
 
-# --- python -m pip (blocked — use uv, MUST be before PYTHON catch-all) ---
-# Uses same bypass as catch-all so --force-python skips ALL python rules
-_rule PYTHON_M_PIP cmd="python" match="-m pip" \
-    block="Use uv instead of python -m pip — faster and manages venvs automatically" \
-    bypass="--force-python" docs="https://docs.astral.sh/uv/"
+    _fix PIP3 \
+        "uv pip install <package>  # uv selects correct Python version automatically" \
+        "uv add <package>          # Add to project dependencies (pyproject.toml)" \
+        "uvx <command>             # Run CLI tools without installing"
 
-_fix PYTHON_M_PIP \
-    "uv pip install <package>  # Drop-in replacement for python -m pip install" \
-    "uv add <package>          # Add to project dependencies"
+    # python -m pip / python3 -m pip — MUST precede catch-all python rules
+    # Uses same bypass as catch-all so --force-python skips ALL python rules
+    _rule PYTHON_M_PIP cmd="python" match="-m pip" \
+        block="Use uv instead of python -m pip — faster and manages venvs automatically" \
+        bypass="--force-python" docs="https://docs.astral.sh/uv/"
 
-# --- python3 -m pip (blocked — use uv, MUST be before PYTHON3 catch-all) ---
-# Uses same bypass as catch-all so --force-python3 skips ALL python3 rules
-_rule PYTHON3_M_PIP cmd="python3" match="-m pip" \
-    block="Use uv instead of python3 -m pip — faster and manages venvs automatically" \
-    bypass="--force-python3" docs="https://docs.astral.sh/uv/"
+    _fix PYTHON_M_PIP \
+        "uv pip install <package>  # Drop-in replacement for python -m pip install" \
+        "uv add <package>          # Add to project dependencies"
 
-_fix PYTHON3_M_PIP \
-    "uv pip install <package>  # Drop-in replacement for python3 -m pip install" \
-    "uv add <package>          # Add to project dependencies"
+    _rule PYTHON3_M_PIP cmd="python3" match="-m pip" \
+        block="Use uv instead of python3 -m pip — faster and manages venvs automatically" \
+        bypass="--force-python3" docs="https://docs.astral.sh/uv/"
 
-# --- python (catch-all — use uv run) ---
-# Catches: python script.py, python -c "code", python -m module, piped python
-_rule PYTHON_DIRECT cmd="python" \
-    block="Use uv run instead of python — uv manages Python versions and venvs automatically" \
-    bypass="--force-python" docs="https://docs.astral.sh/uv/guides/scripts/"
+    _fix PYTHON3_M_PIP \
+        "uv pip install <package>  # Drop-in replacement for python3 -m pip install" \
+        "uv add <package>          # Add to project dependencies"
 
-_fix PYTHON_DIRECT \
-    "uv run script.py              # Run script with managed Python + dependencies" \
-    "uv run python -c 'code'       # Run inline code with managed Python" \
-    "uv run python -m module       # Run module (venv, http.server, etc.)" \
-    "... | uv run python -c 'code' # Pipe data through managed Python"
+fi
 
-# --- python3 (catch-all — use uv run) ---
-# Catches: python3 script.py, python3 -c "code", python3 -m module, piped python3
-_rule PYTHON3_DIRECT cmd="python3" \
-    block="Use uv run instead of python3 — uv manages Python versions and venvs automatically" \
-    bypass="--force-python3" docs="https://docs.astral.sh/uv/guides/scripts/"
+# --- python/python3 direct invocation (blocked — use uv run) ---
+if [[ "${COMMAND_SAFETY_ALLOW_PYTHON:-}" != "true" ]]; then
 
-_fix PYTHON3_DIRECT \
-    "uv run script.py              # Run script with managed Python + dependencies" \
-    "uv run python -c 'code'       # Run inline code with managed Python" \
-    "uv run python -m module       # Run module (venv, http.server, etc.)" \
-    "... | uv run python -c 'code' # Pipe data through managed Python"
+    # Catches: python script.py, python -c "code", python -m module, piped python
+    _rule PYTHON_DIRECT cmd="python" \
+        block="Use uv run instead of python — uv manages Python versions and venvs automatically" \
+        bypass="--force-python" docs="https://docs.astral.sh/uv/guides/scripts/"
+
+    _fix PYTHON_DIRECT \
+        "uv run script.py              # Run script with managed Python + dependencies" \
+        "uv run python -c 'code'       # Run inline code with managed Python" \
+        "uv run python -m module       # Run module (venv, http.server, etc.)" \
+        "... | uv run python -c 'code' # Pipe data through managed Python"
+
+    # Catches: python3 script.py, python3 -c "code", python3 -m module, piped python3
+    _rule PYTHON3_DIRECT cmd="python3" \
+        block="Use uv run instead of python3 — uv manages Python versions and venvs automatically" \
+        bypass="--force-python3" docs="https://docs.astral.sh/uv/guides/scripts/"
+
+    _fix PYTHON3_DIRECT \
+        "uv run script.py              # Run script with managed Python + dependencies" \
+        "uv run python -c 'code'       # Run inline code with managed Python" \
+        "uv run python -m module       # Run module (venv, http.server, etc.)" \
+        "... | uv run python -c 'code' # Pipe data through managed Python"
+
+fi
 
 # --- composer (blocked — use bun) ---
 _rule COMPOSER_BLOCK cmd="composer" \

--- a/lib/command-safety/rules/settings.sh
+++ b/lib/command-safety/rules/settings.sh
@@ -23,6 +23,13 @@
 #   COMMAND_SAFETY_DISABLE_NEXTJS             - Next.js rules
 #   COMMAND_SAFETY_DISABLE_PACKAGE_MANAGERS   - Package manager rules
 #   COMMAND_SAFETY_DISABLE_DANGEROUS_COMMANDS - Generic dangerous commands
+# Per-manager allow flags (fine-grained; set before shell-config is sourced):
+#   COMMAND_SAFETY_ALLOW_NPM=true    - Allow npm (yarn/pnpm still blocked)
+#   COMMAND_SAFETY_ALLOW_NPX=true    - Allow npx
+#   COMMAND_SAFETY_ALLOW_YARN=true   - Allow yarn
+#   COMMAND_SAFETY_ALLOW_PNPM=true   - Allow pnpm
+#   COMMAND_SAFETY_ALLOW_PIP=true    - Allow pip/pip3 (python/python3 still blocked)
+#   COMMAND_SAFETY_ALLOW_PYTHON=true - Allow python/python3 direct invocation
 # Example:
 #   # In ~/.bashrc or ~/.zshrc, before sourcing shell-config:
 #   export COMMAND_SAFETY_DISABLE_NGINX=true      # Don't use nginx

--- a/tests/regression/package-manager-allow-vars.bats
+++ b/tests/regression/package-manager-allow-vars.bats
@@ -1,0 +1,237 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Regression: Per-manager COMMAND_SAFETY_ALLOW_* env var tests
+# =============================================================================
+# Verifies that each ALLOW_ flag unblocks only its own manager and leaves
+# all others blocked. Return codes from _check_command_rules:
+#   0 = checked + allowed   1 = blocked   2 = no rule registered (also = allow)
+# Tests use [ "$status" -ne 1 ] to mean "not blocked" (covers both 0 and 2).
+# =============================================================================
+
+setup() {
+    export SHELL_CONFIG_DIR
+    SHELL_CONFIG_DIR="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+    export ENGINE_DIR="$SHELL_CONFIG_DIR/lib/command-safety/engine"
+    export REGISTRY="$ENGINE_DIR/registry.sh"
+    export UTILS="$ENGINE_DIR/utils.sh"
+    export RULE_HELPERS="$ENGINE_DIR/rule-helpers.sh"
+    export MATCHER="$ENGINE_DIR/matcher.sh"
+    export PKG_RULES="$SHELL_CONFIG_DIR/lib/command-safety/rules/package-managers.sh"
+}
+
+# Emit code to source the engine + rule file in a fresh bash -c subshell
+_engine_with_rules() {
+    cat << 'SHELL'
+        set -euo pipefail
+        _show_rule_message() { :; }
+        _log_violation() { :; }
+SHELL
+    echo "source '$REGISTRY'"
+    echo "source '$UTILS'"
+    echo "source '$RULE_HELPERS'"
+    echo "source '$PKG_RULES'"
+    echo "source '$MATCHER'"
+}
+
+# =============================================================================
+# Node managers
+# =============================================================================
+
+@test "ALLOW_NPM: npm not blocked when COMMAND_SAFETY_ALLOW_NPM=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_NPM=true
+        $(_engine_with_rules)
+        _check_command_rules npm install lodash
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_NPM: yarn still blocked when only COMMAND_SAFETY_ALLOW_NPM=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_NPM=true
+        $(_engine_with_rules)
+        _check_command_rules yarn add lodash
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "ALLOW_NPM: pnpm still blocked when only COMMAND_SAFETY_ALLOW_NPM=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_NPM=true
+        $(_engine_with_rules)
+        _check_command_rules pnpm install lodash
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "ALLOW_NPX: npx not blocked when COMMAND_SAFETY_ALLOW_NPX=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_NPX=true
+        $(_engine_with_rules)
+        _check_command_rules npx create-react-app my-app
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_NPX: npm still blocked when only COMMAND_SAFETY_ALLOW_NPX=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_NPX=true
+        $(_engine_with_rules)
+        _check_command_rules npm install lodash
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "ALLOW_YARN: yarn not blocked when COMMAND_SAFETY_ALLOW_YARN=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_YARN=true
+        $(_engine_with_rules)
+        _check_command_rules yarn add lodash
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_YARN: npm still blocked when only COMMAND_SAFETY_ALLOW_YARN=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_YARN=true
+        $(_engine_with_rules)
+        _check_command_rules npm install lodash
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "ALLOW_PNPM: pnpm not blocked when COMMAND_SAFETY_ALLOW_PNPM=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PNPM=true
+        $(_engine_with_rules)
+        _check_command_rules pnpm install lodash
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_PNPM: yarn still blocked when only COMMAND_SAFETY_ALLOW_PNPM=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PNPM=true
+        $(_engine_with_rules)
+        _check_command_rules yarn add lodash
+    "
+    [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# Python tools
+# =============================================================================
+
+@test "ALLOW_PIP: pip not blocked when COMMAND_SAFETY_ALLOW_PIP=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PIP=true
+        $(_engine_with_rules)
+        _check_command_rules pip install requests
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_PIP: pip3 not blocked when COMMAND_SAFETY_ALLOW_PIP=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PIP=true
+        $(_engine_with_rules)
+        _check_command_rules pip3 install requests
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_PIP: python still blocked when only COMMAND_SAFETY_ALLOW_PIP=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PIP=true
+        $(_engine_with_rules)
+        _check_command_rules python script.py
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "ALLOW_PIP: python3 still blocked when only COMMAND_SAFETY_ALLOW_PIP=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PIP=true
+        $(_engine_with_rules)
+        _check_command_rules python3 script.py
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "ALLOW_PYTHON: python not blocked when COMMAND_SAFETY_ALLOW_PYTHON=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PYTHON=true
+        $(_engine_with_rules)
+        _check_command_rules python script.py
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_PYTHON: python3 not blocked when COMMAND_SAFETY_ALLOW_PYTHON=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PYTHON=true
+        $(_engine_with_rules)
+        _check_command_rules python3 script.py
+    "
+    [ "$status" -ne 1 ]
+}
+
+@test "ALLOW_PYTHON: pip still blocked when only COMMAND_SAFETY_ALLOW_PYTHON=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PYTHON=true
+        $(_engine_with_rules)
+        _check_command_rules pip install requests
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "ALLOW_PYTHON: pip3 still blocked when only COMMAND_SAFETY_ALLOW_PYTHON=true" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PYTHON=true
+        $(_engine_with_rules)
+        _check_command_rules pip3 install requests
+    "
+    [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# Independence: node allows don't affect python and vice versa
+# =============================================================================
+
+@test "independence: all node ALLOW vars set, python still blocked" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_NPM=true COMMAND_SAFETY_ALLOW_NPX=true
+        export COMMAND_SAFETY_ALLOW_YARN=true COMMAND_SAFETY_ALLOW_PNPM=true
+        $(_engine_with_rules)
+        _check_command_rules python script.py
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "independence: all node ALLOW vars set, pip still blocked" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_NPM=true COMMAND_SAFETY_ALLOW_YARN=true COMMAND_SAFETY_ALLOW_PNPM=true
+        $(_engine_with_rules)
+        _check_command_rules pip install requests
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "independence: ALLOW_PIP + ALLOW_PYTHON set, npm still blocked" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PIP=true COMMAND_SAFETY_ALLOW_PYTHON=true
+        $(_engine_with_rules)
+        _check_command_rules npm install lodash
+    "
+    [ "$status" -eq 1 ]
+}
+
+@test "independence: ALLOW_PIP + ALLOW_PYTHON set, yarn still blocked" {
+    run bash -c "
+        export COMMAND_SAFETY_ALLOW_PIP=true COMMAND_SAFETY_ALLOW_PYTHON=true
+        $(_engine_with_rules)
+        _check_command_rules yarn add lodash
+    "
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

- Adds `COMMAND_SAFETY_ALLOW_*` env vars so each package manager can be individually unblocked without touching the others
- All blocking rules remain active by default — this is purely opt-in per manager
- `COMMAND_SAFETY_DISABLE_PACKAGE_MANAGERS=true` still works as an all-or-nothing kill switch

## New vars

Set in `~/.zshrc.local` before shell-config is sourced:

```bash
# Node/JS — unblock specific managers only
export COMMAND_SAFETY_ALLOW_NPM=true   # unblocks npm (yarn/pnpm still blocked)
export COMMAND_SAFETY_ALLOW_NPX=true   # unblocks npx
export COMMAND_SAFETY_ALLOW_YARN=true  # unblocks yarn
export COMMAND_SAFETY_ALLOW_PNPM=true  # unblocks pnpm

# Python — pip and python/python3 are independently configurable
export COMMAND_SAFETY_ALLOW_PIP=true    # unblocks pip/pip3 (python still blocked)
export COMMAND_SAFETY_ALLOW_PYTHON=true # unblocks python/python3 (pip still blocked)
```

## Tests

21 new regression tests in `tests/regression/package-manager-allow-vars.bats` cover:
- Each allow var unblocks only its own manager
- All other managers remain blocked when only one allow is set
- Node allow vars don't affect Python rules and vice versa

Closes #2